### PR TITLE
Simplify nil argument handling using early normalization

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -485,7 +485,7 @@ defmodule AshAi do
             case action.type do
               :read ->
                 sort =
-                  case arguments && arguments["sort"] do
+                  case arguments["sort"] do
                     sort when is_list(sort) ->
                       Enum.map(sort, fn map ->
                         case map["direction"] || "asc" do
@@ -500,7 +500,7 @@ defmodule AshAi do
                   |> Enum.join(",")
 
                 limit =
-                  case {arguments && arguments["limit"], action.pagination} do
+                  case {arguments["limit"], action.pagination} do
                     {limit, false} when is_integer(limit) ->
                       limit
 
@@ -521,7 +521,7 @@ defmodule AshAi do
 
                 resource
                 |> Ash.Query.limit(limit)
-                |> Ash.Query.offset(arguments && arguments["offset"])
+                |> Ash.Query.offset(arguments["offset"])
                 |> then(fn query ->
                   if sort != "" do
                     Ash.Query.sort_input(query, sort)


### PR DESCRIPTION
## Summary
- Simplified the nil argument handling by normalizing arguments to an empty map at the beginning of the function
- Removed redundant `arguments &&` checks throughout the code
- This addresses feedback from the upstream PR review

## Changes
- Removed `arguments &&` checks from:
  - Sort case statement (line 488)
  - Limit case statement (line 503)  
  - Offset query (line 524)

The early normalization at line 463 (`arguments = arguments || %{}`) ensures that all subsequent accesses are safe without additional nil checks.