### PR TITLE
Fix BadMapError when LangChain/MCP calls tools without arguments

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -485,7 +485,7 @@ defmodule AshAi do
             case action.type do
               :read ->
                 sort =
-                  case arguments && arguments["sort"] do
+                  case arguments["sort"] do
                     sort when is_list(sort) ->
                       Enum.map(sort, fn map ->
                         case map["direction"] || "asc" do
@@ -500,7 +500,7 @@ defmodule AshAi do
                   |> Enum.join(",")
 
                 limit =
-                  case {arguments && arguments["limit"], action.pagination} do
+                  case {arguments["limit"], action.pagination} do
                     {limit, false} when is_integer(limit) ->
                       limit
 
@@ -521,7 +521,7 @@ defmodule AshAi do
 
                 resource
                 |> Ash.Query.limit(limit)
-                |> Ash.Query.offset(arguments && arguments["offset"])
+                |> Ash.Query.offset(arguments["offset"])
                 |> then(fn query ->
                   if sort != "" do
                     Ash.Query.sort_input(query, sort)


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where AshAi crashes with `BadMapError: expected a map, got: nil` when LangChain or MCP clients call tools without providing arguments.

## Problem

Some LangChain/MCP implementations send `nil` instead of an empty object `{}` when calling tools that have no required parameters. This causes AshAi to fail when trying to access properties like `arguments["filter"]`.

## Solution

- Added nil-safety check at the beginning of the tool function: `arguments = arguments || %{}`
- This ensures all subsequent code can safely access argument properties
- Based on review feedback, simplified the approach by normalizing arguments early rather than checking for nil throughout

## Changes

- **lib/ash_ai.ex**: Added early normalization of nil arguments to empty map
- **test/ash_ai/tool_test.exs**: Added test case to verify tools can be called with nil arguments

## Impact

- ✅ Fixes crashes for tools with no required arguments
- ✅ Improves compatibility with various LangChain/MCP client implementations  
- ✅ No breaking changes - existing code continues to work as before

## Testing

Added comprehensive test that simulates LangChain/MCP sending nil arguments and verifies the tool handles it gracefully.

Fixes the issue where tools fail with:
```
** (BadMapError) expected a map, got: nil
```

## Upstream PR
This fix has also been submitted upstream as PR ash-project/ash_ai#118